### PR TITLE
sdm: core: allow to skip refresh rate changes

### DIFF
--- a/include/display_properties.h
+++ b/include/display_properties.h
@@ -133,4 +133,6 @@
 #define DISABLE_IDLE_TIME_HDR                DISPLAY_PROP("disable_idle_time_hdr")
 #define ENABLE_POMS_DURING_DOZE              DISPLAY_PROP("enable_poms_during_doze")
 
+#define SKIP_REFRESH_RATE_CHANGE             DISPLAY_PROP("skip_refresh_rate_change")
+
 #endif  // __DISPLAY_PROPERTIES_H__

--- a/sdm/libs/core/display_builtin.cpp
+++ b/sdm/libs/core/display_builtin.cpp
@@ -119,6 +119,10 @@ DisplayError DisplayBuiltIn::Init() {
   Debug::Get()->GetProperty(DEFER_FPS_FRAME_COUNT, &value);
   deferred_config_.frame_count = (value > 0) ? UINT32(value) : 0;
 
+  value = 0;
+  Debug::Get()->GetProperty(SKIP_REFRESH_RATE_CHANGE, &value);
+  skip_refresh_rate_change_ = (value == 1);
+
   return error;
 }
 
@@ -444,7 +448,8 @@ DisplayError DisplayBuiltIn::TeardownConcurrentWriteback(void) {
 DisplayError DisplayBuiltIn::SetRefreshRate(uint32_t refresh_rate, bool final_rate) {
   lock_guard<recursive_mutex> obj(recursive_mutex_);
 
-  if (!active_ || !hw_panel_info_.dynamic_fps || qsync_mode_ != kQSyncModeNone) {
+  if (!active_ || !hw_panel_info_.dynamic_fps || qsync_mode_ != kQSyncModeNone
+      || skip_refresh_rate_change_) {
     return kErrorNotSupported;
   }
 

--- a/sdm/libs/core/display_builtin.h
+++ b/sdm/libs/core/display_builtin.h
@@ -163,6 +163,7 @@ class DisplayBuiltIn : public DisplayBase, HWEventHandler, DppsPropIntf {
   recursive_mutex brightness_lock_;
   float cached_brightness_ = 0.0f;
   bool pending_brightness_ = false;
+  bool skip_refresh_rate_change_ = false;
 };
 
 }  // namespace sdm


### PR DESCRIPTION
* This function makes the screen change the refresh rate constantly
  in some situations, and this produces flicker on the display

* Devices may opt-out of this function by setting the property
  vendor.display.skip_refresh_rate_change to 1

* The refresh rate is still successfully changed even with this
  function disabled

test: set the property vendor.display.skip_refresh_rate_change to 1,
      ensure that no flicker is visible, that the panel refresh
      rate isn't randomly changed, and that the refresh rate
      can be manually changed

Signed-off-by: daniml3 <danimoral1001@gmail.com>
Change-Id: I613d04da10daeb7d7963d3c5d4816d3d260c98c7